### PR TITLE
Fix media lookup using literal '$isbn' string

### DIFF
--- a/web/modules/custom/books_book_managment/src/Services/CoverDownloadService.php
+++ b/web/modules/custom/books_book_managment/src/Services/CoverDownloadService.php
@@ -166,7 +166,7 @@ class CoverDownloadService {
    */
   protected function getMediaByIsbn(string $isbn) {
     $result = $this->entityTypeManager->getStorage('media')->getQuery()
-      ->condition('name', '$isbn')
+      ->condition('name', $isbn)
       ->accessCheck()
       ->execute();
     return (empty($result)) ? FALSE : $this->entityTypeManager->getStorage('media')


### PR DESCRIPTION
## Summary
- Fixed `getMediaByIsbn()` querying for the literal string `'$isbn'` instead of the `$isbn` variable value
- This caused duplicate media entities to be created on every call since existing ones were never found

## Test plan
- [ ] Verify that adding a book with an existing cover no longer creates a duplicate media entity
- [ ] Verify that `getMediaByIsbn()` correctly returns existing media for known ISBNs

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)