### PR TITLE
Remove duplicate API call in getFormatedBookData()

### DIFF
--- a/web/modules/custom/books_book_managment/src/Services/GoogleBooksService.php
+++ b/web/modules/custom/books_book_managment/src/Services/GoogleBooksService.php
@@ -77,7 +77,6 @@ class GoogleBooksService implements BookDataServiceInterface {
    */
   public function getFormatedBookData(int|string $isbn): array|null {
     $bookData = $this->getBookData($isbn);
-    $bookData = $this->getBookData($isbn);
     return ($bookData) ? $this->formatBookData($bookData) : $bookData;
   }
 

--- a/web/modules/custom/books_book_managment/tests/src/Unit/Services/GoogleBooksServiceTest.php
+++ b/web/modules/custom/books_book_managment/tests/src/Unit/Services/GoogleBooksServiceTest.php
@@ -232,8 +232,7 @@ class GoogleBooksServiceTest extends UnitTestCase {
 
     $response = new Response(200, [], json_encode($mockData));
 
-    // getFormatedBookData calls getBookData twice (known bug in source).
-    $this->httpClient->expects($this->exactly(2))
+    $this->httpClient->expects($this->once())
       ->method('request')
       ->willReturn($response);
 


### PR DESCRIPTION
## Summary
- Removed duplicate `$this->getBookData($isbn)` call in `GoogleBooksService::getFormatedBookData()`
- Updated test expectation from `exactly(2)` to `once()`

## Test plan
- [ ] Run `ddev phpunit` — tests should pass with single API call expectation

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)