### PR TITLE
Remove count() calls on integer variables in batch callback

### DIFF
--- a/web/modules/custom/books_book_managment/src/Batches/MissingCoverBatch.php
+++ b/web/modules/custom/books_book_managment/src/Batches/MissingCoverBatch.php
@@ -63,9 +63,9 @@ class MissingCoverBatch {
       $failure = count($results['failure']);
       $success = count($results['success']);
       $total = $failure + $success;
-      $messenger->addMessage(t('@count results processed.', ['@count' => count($total)]));
-      $messenger->addMessage(t('@count covers found.', ['@count' => count($success)]));
-      $messenger->addMessage(t('@count covers not found.', ['@count' => count($failure)]));
+      $messenger->addMessage(t('@count results processed.', ['@count' => $total]));
+      $messenger->addMessage(t('@count covers found.', ['@count' => $success]));
+      $messenger->addMessage(t('@count covers not found.', ['@count' => $failure]));
     }
     else {
       // An error occurred.


### PR DESCRIPTION
## Summary
- Removed `count()` wrappers around `$total`, `$success`, and `$failure` in `MissingCoverBatch::missingCoverBatchFinished()`
- These variables are already integers from arithmetic, not arrays

## Test plan
- [ ] Run batch cover update and verify completion messages display correct counts

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)