### PR TITLE
Replace LIKE query with exact match for term lookup

### DIFF
--- a/web/modules/custom/books_activity/src/Controller/ActivityController.php
+++ b/web/modules/custom/books_activity/src/Controller/ActivityController.php
@@ -134,7 +134,7 @@ class ActivityController extends ControllerBase {
    */
   protected function getStatusByName(string $name): ?int {
     $results = $this->entityTypeManager->getStorage('taxonomy_term')->getQuery()
-      ->condition('name', "%$name%", 'LIKE')
+      ->condition('name', $name)
       ->condition('vid', 'sta')
       ->accessCheck()
       ->execute();


### PR DESCRIPTION
## Summary
- Replaced `->condition('name', "%\$name%", 'LIKE')` with exact match `->condition('name', \$name)` in `ActivityController::getStatusByName()`
- Prevents matching unintended taxonomy terms with similar names

## Test plan
- [ ] Verify starting, finishing, and abandoning activities still assigns the correct status

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)