### PR TITLE
Add API key validation and URL encoding in GoogleBooksService

### DIFF
--- a/web/modules/custom/books_book_managment/src/Services/GoogleBooksService.php
+++ b/web/modules/custom/books_book_managment/src/Services/GoogleBooksService.php
@@ -33,7 +33,12 @@ class GoogleBooksService implements BookDataServiceInterface {
    */
   public function getBookData(string|int $isbn): array|null {
     $googleApiKey = $this->settings->get('google_api_key');
-    $uri = 'https://www.googleapis.com/books/v1/volumes?q=isbn:' . $isbn . '&key=' . $googleApiKey;
+    if (empty($googleApiKey)) {
+      $this->loggerChannelFactory->get('GoogleBooksService')
+        ->warning('Google API key is not configured.');
+      return NULL;
+    }
+    $uri = 'https://www.googleapis.com/books/v1/volumes?q=isbn:' . urlencode((string) $isbn) . '&key=' . urlencode($googleApiKey);
     $data = NULL;
     try {
       $request = $this->httpClient->request('GET', $uri);


### PR DESCRIPTION
## Summary
- Added null/empty check on Google API key with warning log if not configured
- URL-encoded both ISBN and API key parameters in the request URI

## Test plan
- [ ] Verify book lookup still works with a valid API key
- [ ] Verify a warning is logged when the API key is missing

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)