### PR TITLE
Replace FQCN with proper service ID in books.theme

### DIFF
--- a/web/themes/custom/books/books.theme
+++ b/web/themes/custom/books/books.theme
@@ -9,7 +9,7 @@
  * Implements hook_preprocess_html().
  */
 function books_preprocess_html(&$variables) {
-  $themeSettings = \Drupal::service('Drupal\Core\Extension\ThemeSettingsProvider');
+  $themeSettings = \Drupal::service('theme_settings_provider');
   $variables['attributes']['style'] =
     ';--primary:' . $themeSettings->getSetting('primary') .
     ';--secondary: ' . $themeSettings->getSetting('secondary') .


### PR DESCRIPTION
## Summary
- Replaced `'Drupal\Core\Extension\ThemeSettingsProvider'` FQCN with `'theme_settings_provider'` service ID
- Using FQCNs as service IDs is fragile and breaks if the class is moved or renamed

## Test plan
- [ ] Verify theme settings (colors) still render correctly on the frontend
- [ ] Clear cache and verify no service not found errors

Closes #43
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)