### PR TITLE
Fix uninitialized $data in OpenLibraryService::getBookData()

### DIFF
--- a/web/modules/custom/books_book_managment/src/Services/OpenLibraryService.php
+++ b/web/modules/custom/books_book_managment/src/Services/OpenLibraryService.php
@@ -29,6 +29,7 @@ class OpenLibraryService implements BookDataServiceInterface {
    */
   public function getBookData(string|int $isbn): array|null {
     $uri = 'https://openlibrary.org/api/books?jscmd=data&format=json&bibkeys=ISBN:' . $isbn;
+    $data = NULL;
 
     try {
       $request = $this->httpClient->request('GET', $uri);
@@ -39,7 +40,7 @@ class OpenLibraryService implements BookDataServiceInterface {
         ->alert($e->getCode() . ' : ' . $e->getMessage());
     }
 
-    if (!isset($data['ISBN:' . $isbn])) {
+    if ($data === NULL || !isset($data['ISBN:' . $isbn])) {
       $this->loggerChannelFactory->get('OpenLibraryService')
         ->alert('No data fo ISBN : ' . $isbn . '(' . $uri . ')');
       return NULL;


### PR DESCRIPTION
## Summary
- Initialize `$data = NULL` before the try block
- Added explicit null check before accessing `$data['ISBN:' . $isbn]`

## Test plan
- [ ] Run `ddev phpunit` — OpenLibraryService tests should pass

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)