### PR TITLE
Fix BookCover::getFirstReference() to handle empty references

### DIFF
--- a/web/modules/custom/books_activity/src/Plugin/ExtraField/Display/BookCover.php
+++ b/web/modules/custom/books_activity/src/Plugin/ExtraField/Display/BookCover.php
@@ -77,8 +77,11 @@ class BookCover extends ExtraFieldPlusDisplayBase implements ContainerFactoryPlu
    * @return \Drupal\Core\Entity\EntityInterface
    *   The First entity referenced inf given field.
    */
-  protected function getFirstReference(EntityInterface $entity, string $fieldName): EntityInterface {
+  protected function getFirstReference(EntityInterface $entity, string $fieldName): ?EntityInterface {
     $referencedEntities = $entity->get($fieldName)->referencedEntities();
+    if (empty($referencedEntities)) {
+      return NULL;
+    }
     return reset($referencedEntities);
   }
 


### PR DESCRIPTION
## Summary
- Changed return type from `EntityInterface` to `?EntityInterface`
- Added empty array check before calling `reset()` to avoid returning `false`

## Test plan
- [ ] View an activity with a book that has no cover — should not crash

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)