### PR TITLE
Add null coalescing for optional fields in formatBookData()

### DIFF
--- a/web/modules/custom/books_book_managment/src/Services/GoogleBooksService.php
+++ b/web/modules/custom/books_book_managment/src/Services/GoogleBooksService.php
@@ -56,13 +56,15 @@ class GoogleBooksService implements BookDataServiceInterface {
    * {@inheritdoc}
    */
   public function formatBookData(array $bookData): array {
-    $release = date('Y-m-d', strtotime($bookData['volumeInfo']['publishedDate']));
-    $formattedBookData['title'] = $bookData['volumeInfo']['title'];
-    $formattedBookData['field_pages'] = $bookData['volumeInfo']['pageCount'];
-    $formattedBookData['field_authors'] = $bookData['volumeInfo']['authors'];
-    $formattedBookData['field_publisher'] = $bookData['volumeInfo']['publisher'];
-    $formattedBookData['field_excerpt'] = $bookData['volumeInfo']['description'];
-    foreach ($bookData['volumeInfo']['industryIdentifiers'] as $industryIdentifier) {
+    $volumeInfo = $bookData['volumeInfo'] ?? [];
+    $publishedDate = $volumeInfo['publishedDate'] ?? NULL;
+    $release = $publishedDate ? date('Y-m-d', strtotime($publishedDate)) : NULL;
+    $formattedBookData['title'] = $volumeInfo['title'] ?? '';
+    $formattedBookData['field_pages'] = $volumeInfo['pageCount'] ?? NULL;
+    $formattedBookData['field_authors'] = $volumeInfo['authors'] ?? [];
+    $formattedBookData['field_publisher'] = $volumeInfo['publisher'] ?? NULL;
+    $formattedBookData['field_excerpt'] = $volumeInfo['description'] ?? NULL;
+    foreach ($volumeInfo['industryIdentifiers'] ?? [] as $industryIdentifier) {
       if ($industryIdentifier['type'] === 'ISBN_13') {
         $formattedBookData['field_isbn'] = $industryIdentifier['identifier'];
       }


### PR DESCRIPTION
## Summary
- Added null coalescing (`??`) for all optional Google Books API fields
- Prevents undefined array key warnings when API response is missing fields

## Test plan
- [ ] Run `ddev phpunit` — formatBookData tests should pass
- [ ] Add a book with sparse API data — should not crash

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)