### PR TITLE
Enable page cache with 1 hour max age

### DIFF
--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ
 cache:
   page:
-    max_age: 0
+    max_age: 3600
 css:
   preprocess: true
   gzip: true


### PR DESCRIPTION
## Summary
- Changed \`cache.page.max_age\` from \`0\` to \`3600\` (1 hour)
- Enables page caching for anonymous users

## Test plan
- [ ] Import config with \`ddev drush cim\`
- [ ] Verify anonymous page loads are cached (check response headers)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)