### PR TITLE
Remove undefined books/messages library reference

### DIFF
--- a/web/themes/custom/books/books.info.yml
+++ b/web/themes/custom/books/books.info.yml
@@ -4,7 +4,6 @@ type: theme
 version: 1.0.0
 libraries:
   - books/base
-  - books/messages
   - core/normalize
 description: ''
 core_version_requirement: ^10 || ^11


### PR DESCRIPTION
## Summary
- Removed \`books/messages\` from \`books.info.yml\` libraries list
- This library was never defined in \`books.libraries.yml\`, causing a warning
- Status messages are already styled via the base theme CSS

## Test plan
- [x] Clear cache and verify no library warning in logs
- [x] Verify status messages still display correctly

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)