### PR TITLE
Fix package.json description referencing 'Lug'

### DIFF
--- a/web/themes/custom/books/package.json
+++ b/web/themes/custom/books/package.json
@@ -1,7 +1,7 @@
 {
   "name": "books",
   "version": "2.0.0",
-  "description": "Lug Theme's front End dependencies",
+  "description": "Books theme frontend dependencies",
   "author": "Corentin Bessire",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- Changed description from \"Lug Theme's front End dependencies\" to \"Books theme frontend dependencies\"

## Test plan
- [ ] No functional impact — metadata only

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)