### PR TITLE
Fix Vite build to use production mode by default

### DIFF
--- a/web/themes/custom/books/package.json
+++ b/web/themes/custom/books/package.json
@@ -5,7 +5,8 @@
   "author": "Corentin Bessire",
   "license": "GPL-3.0",
   "scripts": {
-    "build": "vite build --mode development",
+    "build": "vite build",
+    "build:dev": "vite build --mode development",
     "watch": "vite build --watch --mode development",
     "dev": "vite",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- Changed \`build\` script from \`vite build --mode development\` to \`vite build\` (production)
- Added \`build:dev\` script for development builds when needed

## Test plan
- [x] Run \`ddev books:build\` — should produce minified output
- [ ] Run \`ddev books:npm run build:dev\` — should produce development output

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)