### PR TITLE
Remove views_ui from production config

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -46,7 +46,6 @@ module:
   token: 0
   toolbar: 0
   user: 0
-  views_ui: 0
   webp: 0
   pathauto: 1
   views: 10


### PR DESCRIPTION
## Summary
- Removed \`views_ui: 0\` from \`core.extension.yml\` module list
- views_ui is a development-only module that should not be in production config

## Test plan
- [ ] Import config with \`ddev drush cim\` — views_ui should be uninstalled
- [ ] Verify views still work (views module remains enabled)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)