### PR TITLE
Set site email to hello@gealion.ch

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -3,7 +3,7 @@ _core:
 langcode: en
 uuid: 6f51d33e-5f11-40ed-908d-3a105fba2236
 name: 'My Library'
-mail: admin@example.com
+mail: hello@gealion.ch
 slogan: ''
 page:
   403: ''


### PR DESCRIPTION
## Summary
- Replace default `admin@example.com` placeholder with `hello@gealion.ch` in `config/sync/system.site.yml`

## Test plan
- [x] Import config with `drush cim` and verify site email is updated in Admin > Configuration > Basic site settings

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)