### PR TITLE
chore (deps): Drupal dependency updates 2026-06-08

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2849,17 +2849,17 @@
         },
         {
             "name": "drupal/search_api",
-            "version": "1.40.0",
+            "version": "1.41.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/search_api.git",
-                "reference": "8.x-1.40"
+                "reference": "8.x-1.41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.40.zip",
-                "reference": "8.x-1.40",
-                "shasum": "64ac71887786da63ced27a43e37342ea3b765a88"
+                "url": "https://ftp.drupal.org/files/projects/search_api-8.x-1.41.zip",
+                "reference": "8.x-1.41",
+                "shasum": "bb030951ee9a09fac67e8cde5b495c3b67e2949d"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11"
@@ -2881,8 +2881,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.40",
-                    "datestamp": "1762031191",
+                    "version": "8.x-1.41",
+                    "datestamp": "1780907071",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2920,7 +2920,7 @@
         },
         {
             "name": "drupal/search_api_db",
-            "version": "1.40.0",
+            "version": "1.41.0",
             "require": {
                 "drupal/core": "^10.2 || ^11",
                 "drupal/search_api": "*"
@@ -2928,8 +2928,8 @@
             "type": "metapackage",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.40",
-                    "datestamp": "1762031191",
+                    "version": "8.x-1.41",
+                    "datestamp": "1780907071",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -2323,17 +2323,17 @@
         },
         {
             "name": "drupal/gin",
-            "version": "5.0.14",
+            "version": "5.0.15",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/gin.git",
-                "reference": "5.0.14"
+                "reference": "5.0.15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/gin-5.0.14.zip",
-                "reference": "5.0.14",
-                "shasum": "35a09f852fc189d11c9d279e2f228ef23105e19e"
+                "url": "https://ftp.drupal.org/files/projects/gin-5.0.15.zip",
+                "reference": "5.0.15",
+                "shasum": "b02b1d890cade5e096c1c99a4a18ce7e23a186cd"
             },
             "require": {
                 "drupal/core": "^11.2",
@@ -2342,8 +2342,8 @@
             "type": "drupal-theme",
             "extra": {
                 "drupal": {
-                    "version": "5.0.14",
-                    "datestamp": "1779891891",
+                    "version": "5.0.15",
+                    "datestamp": "1780500810",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Summary

Routine Drupal dependency updates addressing the open dependency-update issues.

| Package | From | To | Type |
|---------|------|-----|------|
| drupal/search_api | 1.40.0 | 1.41.0 | Minor (transitive) |
| drupal/search_api_db | 1.40.0 | 1.41.0 | Minor (direct) |
| drupal/gin | 5.0.14 | 5.0.15 | Patch (direct) |

`search_api` (transitive) was pulled in automatically via `search_api_db --with-dependencies`.

## Verification

- `composer update` ran cleanly; no security advisories reported
- `drush updb` → no pending database updates
- `drush cr` → cache rebuild successful
- Only `composer.lock` changed — no config schema changes from these releases (unrelated local config drift was deliberately excluded)

Resolves #165
Resolves #164
Resolves #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)