### PR TITLE
feat: scan a book barcode to fill the ISBN on /add-book

### DIFF
--- a/web/modules/custom/books_book_managment/src/Form/AddBookForm.php
+++ b/web/modules/custom/books_book_managment/src/Form/AddBookForm.php
@@ -62,10 +62,56 @@ class AddBookForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    // Scope the Alpine "isbnScanner" component (registered in the theme bundle)
+    // to this form so the Scan button and overlay only live on /add-book.
+    $form['#attributes']['x-data'] = 'isbnScanner';
+
     $form['isbn'] = [
       '#type' => 'textfield',
       '#title' => $this->t('ISBN'),
       '#required' => TRUE,
+      // Let the scanner write the decoded barcode into this field.
+      '#attributes' => ['x-ref' => 'isbn'],
+    ];
+
+    // Camera scan button + fullscreen overlay. Rendered via inline_template so
+    // the Alpine attributes survive (a plain #markup would be XSS-filtered).
+    $form['scanner'] = [
+      '#type' => 'inline_template',
+      '#template' => <<<'TWIG'
+        <button type="button" x-on:click="start()"
+          class="mt-2 inline-flex items-center gap-2 rounded-md border border-burgundy bg-cream px-3.5 py-2.5 text-sm font-semibold text-burgundy shadow-sm hover:bg-parchment focus-visible:outline focus-visible:outline-offset-2 focus-visible:outline-burgundy">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z" />
+          </svg>
+          {{ scan_label }}
+        </button>
+
+        <template x-teleport="body">
+          <div x-show="open" x-cloak style="display:none" class="fixed inset-0 z-50 flex flex-col bg-black/90">
+            <div class="flex items-center justify-between p-4 text-white">
+              <span class="text-sm">{{ hint }}</span>
+              <button type="button" x-on:click="stop()"
+                class="rounded-md border border-white/40 px-3 py-1.5 text-sm font-semibold text-white hover:bg-white/10">
+                {{ close_label }}
+              </button>
+            </div>
+            <div class="relative flex flex-1 items-center justify-center overflow-hidden">
+              <video x-ref="video" playsinline muted class="h-full w-full object-cover"></video>
+              <div class="pointer-events-none absolute inset-x-8 top-1/2 h-32 -translate-y-1/2 rounded-lg border-2 border-white/80"></div>
+            </div>
+            <p x-show="starting" class="p-4 text-center text-sm text-white/70">{{ starting_label }}</p>
+            <p x-show="error" x-text="error" class="p-4 text-center text-sm text-red-300"></p>
+          </div>
+        </template>
+        TWIG,
+      '#context' => [
+        'scan_label' => $this->t('Scan barcode'),
+        'hint' => $this->t("Point the camera at the book's barcode"),
+        'close_label' => $this->t('Close'),
+        'starting_label' => $this->t('Starting camera…'),
+      ],
     ];
 
     $form['submit'] = [

--- a/web/themes/custom/books/bun.lock
+++ b/web/themes/custom/books/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "books",
+      "dependencies": {
+        "@zxing/browser": "^0.2.0",
+      },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.17",
         "@vitejs/plugin-legacy": "^7.0.0",
@@ -430,6 +433,12 @@
 
     "@vue/shared": ["@vue/shared@3.1.5", "", {}, "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA=="],
 
+    "@zxing/browser": ["@zxing/browser@0.2.0", "", { "optionalDependencies": { "@zxing/text-encoding": "^0.9.0" }, "peerDependencies": { "@zxing/library": "^0.22.0" } }, "sha512-+ORhrLva0vm6ck74NDCmvYNW3XLoAG81Mu90qfcssN1PBKJjQadxZGeMCcIk+BdJbD/zEAjjHDXOwEK1QCmRtw=="],
+
+    "@zxing/library": ["@zxing/library@0.22.0", "", { "dependencies": { "ts-custom-error": "^3.3.1" }, "optionalDependencies": { "@zxing/text-encoding": "~0.9.0" } }, "sha512-BmInervZV7NwaZWX1LW64sZ4Lh4wxXYFZwGmj98ArPOkRXCtO9b8Gog0Xyh82dsYYGOeRxX+aAhLSq+hQ2XLZQ=="],
+
+    "@zxing/text-encoding": ["@zxing/text-encoding@0.9.0", "", {}, "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -846,6 +855,8 @@
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
+    "ts-custom-error": ["ts-custom-error@3.3.1", "", {}, "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -911,10 +922,6 @@
     "stylelint/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "table/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/web/themes/custom/books/css/tailwind.css
+++ b/web/themes/custom/books/css/tailwind.css
@@ -50,6 +50,11 @@
     border-color: var(--color-stone-300);
   }
 
+  /* Hide Alpine-managed elements until Alpine initializes (prevents flash). */
+  [x-cloak] {
+    display: none !important;
+  }
+
   html {
     font-family: var(--font-body);
     background: var(--color-parchment);

--- a/web/themes/custom/books/js/components/isbn-scanner.js
+++ b/web/themes/custom/books/js/components/isbn-scanner.js
@@ -44,13 +44,13 @@ export default function isbnScanner() {
       const reader = new BrowserMultiFormatReader(hints);
 
       try {
-        this.controls = await reader.decodeFromConstraints(
+        const controls = await reader.decodeFromConstraints(
           { video: { facingMode: 'environment' } },
           video,
-          (result, _error, controls) => {
+          (result, _error, frameControls) => {
             // Keep a handle so stop() can release the camera at any time.
             if (!this.controls) {
-              this.controls = controls;
+              this.controls = frameControls;
             }
             if (!result) {
               return;
@@ -64,6 +64,14 @@ export default function isbnScanner() {
             this.onResult(code);
           },
         );
+        // The camera only finishes starting up here. If the user already
+        // closed the overlay during startup (e.g. while the permission prompt
+        // was showing), release the stream now instead of leaking it.
+        if (!this.open) {
+          controls.stop();
+          return;
+        }
+        this.controls = controls;
       } catch (error) {
         this.handleError(error);
       } finally {

--- a/web/themes/custom/books/js/components/isbn-scanner.js
+++ b/web/themes/custom/books/js/components/isbn-scanner.js
@@ -1,0 +1,124 @@
+import { BrowserMultiFormatReader } from '@zxing/browser';
+import { BarcodeFormat, DecodeHintType } from '@zxing/library';
+
+/**
+ * Alpine component: scan a book barcode (EAN-13) and fill the ISBN field.
+ *
+ * A book's back-cover barcode is an EAN-13 whose digits ARE its ISBN-13, so we
+ * only need to decode the number and write it into the existing ISBN input.
+ *
+ * iOS browsers (incl. Brave/Chrome) run on WebKit, which has no native
+ * BarcodeDetector API, so decoding is done in pure JS by ZXing.
+ *
+ * Expects two refs in the same Alpine scope:
+ * - $refs.isbn:  the ISBN <input> to fill
+ * - $refs.video: the <video> element used as the camera preview
+ */
+export default function isbnScanner() {
+  return {
+    open: false,
+    starting: false,
+    error: '',
+    controls: null,
+
+    /**
+     * Open the overlay and start the camera + decode loop.
+     */
+    async start() {
+      this.error = '';
+      this.starting = true;
+      this.open = true;
+
+      // Let the overlay (and its <video> ref) render before we touch it.
+      await this.$nextTick();
+
+      const video = this.$refs.video;
+      if (!video) {
+        this.starting = false;
+        this.error = this.errorMessage('generic');
+        return;
+      }
+
+      const hints = new Map();
+      hints.set(DecodeHintType.POSSIBLE_FORMATS, [BarcodeFormat.EAN_13]);
+      const reader = new BrowserMultiFormatReader(hints);
+
+      try {
+        this.controls = await reader.decodeFromConstraints(
+          { video: { facingMode: 'environment' } },
+          video,
+          (result, _error, controls) => {
+            // Keep a handle so stop() can release the camera at any time.
+            if (!this.controls) {
+              this.controls = controls;
+            }
+            if (!result) {
+              return;
+            }
+            const code = result.getText();
+            // Books use the Bookland EAN prefix 978/979. Ignore anything else
+            // (price add-ons, non-book products) and keep scanning.
+            if (!/^97[89]/.test(code)) {
+              return;
+            }
+            this.onResult(code);
+          },
+        );
+      } catch (error) {
+        this.handleError(error);
+      } finally {
+        this.starting = false;
+      }
+    },
+
+    /**
+     * Write the scanned ISBN into the field and close the scanner.
+     */
+    onResult(code) {
+      const input = this.$refs.isbn;
+      if (input) {
+        input.value = code;
+        // Notify Drupal/Alpine listeners that the value changed.
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      this.stop();
+    },
+
+    /**
+     * Stop the decode loop, release the camera, and close the overlay.
+     */
+    stop() {
+      if (this.controls) {
+        this.controls.stop();
+        this.controls = null;
+      }
+      this.open = false;
+    },
+
+    /**
+     * Map a getUserMedia error to a friendly message; manual entry still works.
+     */
+    handleError(error) {
+      this.starting = false;
+      if (error && error.name === 'NotAllowedError') {
+        this.error = this.errorMessage('denied');
+      } else if (error && error.name === 'NotFoundError') {
+        this.error = this.errorMessage('notfound');
+      } else {
+        this.error = this.errorMessage('generic');
+      }
+    },
+
+    errorMessage(kind) {
+      const messages = {
+        denied:
+          'Camera access was denied. You can still type the ISBN manually.',
+        notfound: 'No camera was found. You can still type the ISBN manually.',
+        generic:
+          'Could not start the camera. You can still type the ISBN manually.',
+      };
+      return messages[kind] || messages.generic;
+    },
+  };
+}

--- a/web/themes/custom/books/js/main.js
+++ b/web/themes/custom/books/js/main.js
@@ -1,6 +1,9 @@
-import '../css/tailwind.css'
-import Alpine from 'alpinejs'
+import '../css/tailwind.css';
+import Alpine from 'alpinejs';
+import isbnScanner from './components/isbn-scanner.js';
 
-window.Alpine = Alpine
+window.Alpine = Alpine;
 
-Alpine.start()
+Alpine.data('isbnScanner', isbnScanner);
+
+Alpine.start();

--- a/web/themes/custom/books/package.json
+++ b/web/themes/custom/books/package.json
@@ -29,5 +29,8 @@
     "tailwindcss": "^4.1.7",
     "typescript-eslint": "^8.17.0",
     "vite": "^7.0.0"
+  },
+  "dependencies": {
+    "@zxing/browser": "^0.2.0"
   }
 }


### PR DESCRIPTION
## What

Adds a **"Scan barcode"** button to the `/add-book` form. It opens the phone camera, decodes the book's EAN-13 barcode (which *is* the ISBN-13), and fills the ISBN field. The existing pipeline (ISBN validation → Open Library + Google Books lookup → cover download → `book` node creation) is unchanged.

## Why

Typing ISBNs by hand on a phone is slow and error-prone. A book's back-cover barcode already encodes its ISBN, so scanning is just a faster way to fill the field the form already has — no backend changes needed.

## How

- **ZXing** (`@zxing/browser`) does the decoding in pure JS. This is required because every iOS browser — including Brave/Chrome — runs on WebKit, which has **no native `BarcodeDetector` API**.
- Decoding is restricted to **EAN-13**, and only **Bookland prefixes (978/979)** are accepted, so price add-on barcodes and non-book products are ignored while scanning continues.
- An Alpine `isbnScanner` component is **scoped to the form** via `x-data`, so it does not leak onto other ISBN inputs (admin node-edit, etc.). The camera overlay is teleported to `<body>`.
- Camera errors (permission denied / no camera) fall back gracefully — **manual entry always works**.

## Files

- `js/components/isbn-scanner.js` *(new)* — scanner component
- `js/main.js` — register the Alpine component
- `css/tailwind.css` — `[x-cloak]` rule (prevents overlay flash)
- `package.json` / `bun.lock` — add `@zxing/browser`
- `books_book_managment/src/Form/AddBookForm.php` — `x-data` on form, `x-ref` on ISBN input, Scan button + overlay

## Notes / follow-ups

- **Bundle size:** ZXing is bundled into the global `main.js` (~749 kB raw / 152 kB gzip), so it loads on every page. A follow-up could lazy-load it only when "Scan" is first tapped (deferred due to Vite single-file `lib` mode making dynamic-import chunk paths awkward under Drupal's subdirectory).
- **Out of scope:** scan-to-"Start Reading". The same component could later target the existing `activity/start/{isbn}` route.

## Testing

- ✅ `ddev books:build` clean; PHPCS + PHPStan pass (pre-commit)
- ✅ Form renders with all scanner markup
- ⏳ Real-device camera test needs public HTTPS (e.g. `ddev share`) — the phone won't trust DDEV's local cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)