### PR TITLE
fix: fullscreen barcode scanner on mobile

### DIFF
--- a/web/modules/custom/books_book_managment/src/Form/AddBookForm.php
+++ b/web/modules/custom/books_book_managment/src/Form/AddBookForm.php
@@ -89,20 +89,28 @@ class AddBookForm extends FormBase {
         </button>
 
         <template x-teleport="body">
-          <div x-show="open" x-cloak style="display:none" class="fixed inset-0 z-50 flex flex-col bg-black/90">
-            <div class="flex items-center justify-between p-4 text-white">
-              <span class="text-sm">{{ hint }}</span>
-              <button type="button" x-on:click="stop()"
-                class="rounded-md border border-white/40 px-3 py-1.5 text-sm font-semibold text-white hover:bg-white/10">
-                {{ close_label }}
-              </button>
+          <div x-show="open" x-cloak style="display:none" class="fixed inset-0 z-50 bg-black">
+            <!-- Camera preview fills the whole screen. -->
+            <video x-ref="video" playsinline muted class="absolute inset-0 h-full w-full object-cover"></video>
+
+            <!-- Aiming frame, dimming everything around it. -->
+            <div class="pointer-events-none absolute inset-x-8 top-1/2 h-36 -translate-y-1/2 rounded-xl border-2 border-white/80 shadow-[0_0_0_100vmax_rgba(0,0,0,0.45)]"></div>
+
+            <!-- Floating close button (respects the notch / safe areas). -->
+            <button type="button" x-on:click="stop()" aria-label="{{ close_label }}"
+              class="absolute z-10 flex h-12 w-12 items-center justify-center rounded-full bg-black/50 text-white backdrop-blur-sm transition hover:bg-black/70 active:scale-95"
+              style="top:max(1rem,env(safe-area-inset-top));right:max(1rem,env(safe-area-inset-right));">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-6 w-6" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+
+            <!-- Status line at the bottom; only one shows at a time. -->
+            <div class="absolute inset-x-0 bottom-0 p-6 text-center text-sm" style="padding-bottom:max(1.5rem,env(safe-area-inset-bottom))">
+              <p x-show="starting" class="text-white/80">{{ starting_label }}</p>
+              <p x-show="error" x-text="error" class="text-red-300"></p>
+              <p x-show="!starting && !error" class="text-white/90">{{ hint }}</p>
             </div>
-            <div class="relative flex flex-1 items-center justify-center overflow-hidden">
-              <video x-ref="video" playsinline muted class="h-full w-full object-cover"></video>
-              <div class="pointer-events-none absolute inset-x-8 top-1/2 h-32 -translate-y-1/2 rounded-lg border-2 border-white/80"></div>
-            </div>
-            <p x-show="starting" class="p-4 text-center text-sm text-white/70">{{ starting_label }}</p>
-            <p x-show="error" x-text="error" class="p-4 text-center text-sm text-red-300"></p>
           </div>
         </template>
         TWIG,

--- a/web/themes/custom/books/css/tailwind.css
+++ b/web/themes/custom/books/css/tailwind.css
@@ -3,6 +3,9 @@
 @source "../templates/**/*.twig";
 @source "../components/**/*.twig";
 @source "../js/**/*.js";
+/* Custom modules render Twig/inline templates that use theme utility classes. */
+@source "../../../../modules/custom/**/*.php";
+@source "../../../../modules/custom/**/*.twig";
 
 /* ═══════════════════════════════════════════════════════════════════════════
    LITERARY ANTIQUARIAN THEME


### PR DESCRIPTION
## What

Follow-up to #167. Makes the barcode scanner camera view **fullscreen on mobile** with a prominent floating close button.

## Why

On a phone, the camera preview previously sat inside a flex column under a header bar, so it didn't fill the screen. This makes the `<video>` cover the entire viewport with the controls overlaid on top.

## How

- The `<video>` is now `absolute inset-0 object-cover` — it fills the whole screen.
- Close button is a floating circular button (top-right) that respects iOS **safe-area insets** (`env(safe-area-inset-*)`), so it clears the notch.
- The aiming frame dims everything around it (`shadow-[0_0_0_100vmax_…]`) to focus attention.
- Hint / "starting" / error text overlay at the bottom, one at a time, above the home indicator.
- **Tailwind `@source`:** added `web/modules/custom/**/*.{php,twig}` so utility classes used in module `inline_template` markup (like this overlay) are reliably generated. Previously they only worked because they coincidentally matched classes used in theme templates — new utilities (e.g. the arbitrary spotlight shadow, `backdrop-blur-sm`) would otherwise be silently dropped.

## Testing

- `ddev books:build` clean; verified the new utilities (incl. the arbitrary `100vmax` shadow) compile into `build/styles.css`.
- PHPCS + PHPStan pass (pre-commit).
- On-device: camera fills the screen, close button dismisses and releases the camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)