### PR TITLE
fix: resolve Dependabot npm alerts in Cypress test deps

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -931,17 +931,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2011,9 +2011,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2112,13 +2112,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/verror": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,5 +9,9 @@
   },
   "devDependencies": {
     "cypress": "^13.0.0"
+  },
+  "overrides": {
+    "qs": "6.15.2",
+    "uuid": "11.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Resolves all **4 open Dependabot alerts** — every one a transitive dependency under `cypress → @cypress/request` in `tests/package-lock.json`. `npm audit` now reports **0 vulnerabilities**.

| Alert | Package | Severity | Fix | How |
|-------|---------|----------|-----|-----|
| [#205](../../security/dependabot/205) | `form-data` | high | → 4.0.6 | `npm audit fix` |
| [#201](../../security/dependabot/201) | `tmp` | high | → 0.2.7 | `npm audit fix` |
| [#200](../../security/dependabot/200) | `qs` | medium | → 6.15.2 | `overrides` |
| [#199](../../security/dependabot/199) | `uuid` | medium | → 11.1.1 | `overrides` |

## Why two needed `overrides`

`tmp` and `form-data` patched cleanly with `npm audit fix`. But `qs` and `uuid` are pinned by `@cypress/request@3.0.10`'s own ranges (`qs ~6.14.1`, `uuid ^8.3.2`), which exclude the patched releases — so they need explicit npm `overrides`:

```json
"overrides": {
  "qs": "6.15.2",
  "uuid": "11.1.1"
}
```

### Is forcing `uuid` 8 → 11 safe?

Yes. `@cypress/request` uses it only as:

```js
const { v4: uuid } = require('uuid')
// ... uuid()   // always called with NO arguments
```

- The advisory ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)) is a missing buffer bounds check **when a `buf` argument is provided** — never the case here, so the vulnerable path is unreachable.
- The `{ v4 }` named-export API is unchanged across v8→v11, verified working on v11 in the DDEV container.

## Verification
- `npm install` + `npm audit` → **0 vulnerabilities** (was 4).
- Patched versions confirmed installed: `qs 6.15.2`, `uuid 11.1.1`, `tmp 0.2.7`, `form-data 4.0.6`.
- `{ v4 } = require('uuid'); v4()` smoke-tested on v11.

Only `tests/package.json` and `tests/package-lock.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)