### PR TITLE
fix(theme): make ESLint + Stylelint work, fix the errors, and enforce both in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,30 @@ jobs:
         working-directory: ${{ env.THEME_ROOT }}
         run: bun run build
 
+  theme-lint:
+    name: Theme Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: ${{ env.THEME_ROOT }}
+        run: bun install --frozen-lockfile
+
+      # Invoked directly rather than via `bun run eslint`, whose script passes
+      # --fix: CI must report problems, not quietly rewrite the checkout.
+      - name: ESLint
+        working-directory: ${{ env.THEME_ROOT }}
+        run: bunx eslint .
+
+      - name: Stylelint
+        working-directory: ${{ env.THEME_ROOT }}
+        run: bunx stylelint "**/*.css"
+
   phpcs:
     name: PHPCS
     runs-on: ubuntu-latest

--- a/web/themes/custom/books/css/components/node.css
+++ b/web/themes/custom/books/css/components/node.css
@@ -1,4 +1,4 @@
-/ **
+/**
  * @file
  * Visual styles for nodes using Tailwind CSS.
  */

--- a/web/themes/custom/books/css/components/tablesort.css
+++ b/web/themes/custom/books/css/components/tablesort.css
@@ -1,4 +1,4 @@
-/ **
+/**
  * @file
  * Table sort indicator using Tailwind CSS.
  */

--- a/web/themes/custom/books/css/tailwind.css
+++ b/web/themes/custom/books/css/tailwind.css
@@ -3,6 +3,7 @@
 @source "../templates/**/*.twig";
 @source "../components/**/*.twig";
 @source "../js/**/*.js";
+
 /* Custom modules render Twig/inline templates that use theme utility classes. */
 @source "../../../../modules/custom/**/*.php";
 @source "../../../../modules/custom/**/*.twig";
@@ -30,9 +31,9 @@
   --color-ink-muted: #6b5d4d;
 
   /* Typography scale */
-  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
-  --font-body: 'Source Serif 4', 'Palatino Linotype', Palatino, Georgia, serif;
-  --font-accent: 'Cormorant Garamond', Garamond, 'Times New Roman', serif;
+  --font-display: 'Playfair Display', 'Georgia', 'Times New Roman', serif;
+  --font-body: 'Source Serif 4', 'Palatino Linotype', 'Palatino', 'Georgia', serif;
+  --font-accent: 'Cormorant Garamond', 'Garamond', 'Times New Roman', serif;
   --font-mono: 'IBM Plex Mono', 'Courier New', monospace;
 }
 
@@ -85,9 +86,20 @@
     letter-spacing: -0.01em;
   }
 
-  h1 { font-size: 2.75rem; line-height: 1.15; }
-  h2 { font-size: 2rem; line-height: 1.2; }
-  h3 { font-size: 1.5rem; line-height: 1.3; }
+  h1 {
+    font-size: 2.75rem;
+    line-height: 1.15;
+  }
+
+  h2 {
+    font-size: 2rem;
+    line-height: 1.2;
+  }
+
+  h3 {
+    font-size: 1.5rem;
+    line-height: 1.3;
+  }
 
   a {
     color: var(--color-burgundy);
@@ -361,7 +373,7 @@
   }
 
   /* Animations */
-  @keyframes fadeInUp {
+  @keyframes fade-in-up {
     from {
       opacity: 0;
       transform: translateY(20px);
@@ -378,12 +390,12 @@
   }
 
   .animate-fade-in-up {
-    animation: fadeInUp 0.6s ease forwards;
+    animation: fade-in-up 0.6s ease forwards;
   }
 
   .animate-stagger > * {
     opacity: 0;
-    animation: fadeInUp 0.5s ease forwards;
+    animation: fade-in-up 0.5s ease forwards;
   }
 
   .animate-stagger > *:nth-child(1) { animation-delay: 0.05s; }

--- a/web/themes/custom/books/eslint.config.mjs
+++ b/web/themes/custom/books/eslint.config.mjs
@@ -1,0 +1,66 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import prettierRecommended from 'eslint-plugin-prettier/recommended';
+
+export default [
+  {
+    ignores: ['build/**', 'node_modules/**', '.vite/**'],
+  },
+
+  js.configs.recommended,
+
+  // Theme source: ES modules bundled by Vite, running in the browser.
+  {
+    files: ['js/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        Alpine: 'readonly',
+        Drupal: 'readonly',
+        drupalSettings: 'readonly',
+        once: 'readonly',
+      },
+    },
+  },
+
+  // Vite reads its config as ESM but runs it in Node, and injects __dirname.
+  {
+    files: ['vite.config.js'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        __dirname: 'readonly',
+      },
+    },
+  },
+
+  // package.json declares no "type", so the tooling configs are CommonJS.
+  // This file is .mjs precisely so it stays ESM regardless of that.
+  {
+    files: ['prettier.config.js', 'stylelint.config.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: globals.node,
+    },
+  },
+
+  {
+    files: ['eslint.config.mjs'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: globals.node,
+    },
+  },
+
+  ...tseslint.config({
+    files: ['**/*.ts'],
+    extends: [tseslint.configs.recommended],
+  }),
+
+  // Must stay last: switches off rules that would fight Prettier.
+  prettierRecommended,
+];

--- a/web/themes/custom/books/stylelint.config.js
+++ b/web/themes/custom/books/stylelint.config.js
@@ -13,11 +13,20 @@ module.exports = {
           'screen',
           'config',
           'theme',
+          'source',
+          'utility',
+          'variant',
+          'plugin',
+          'reference',
           'custom-media',
           'custom-selector',
         ],
       },
     ],
+    // Tailwind/Vite inline these @imports at build time, so the browser never
+    // sees them and their position is not a spec violation. Hoisting them above
+    // @theme/@layer to satisfy the rule would reorder the cascade.
+    'no-invalid-position-at-import-rule': null,
     'at-rule-empty-line-before': null,
     'declaration-empty-line-before': null,
     'rule-empty-line-before': null,


### PR DESCRIPTION
Found while establishing a baseline for #184: **neither theme linter worked, and neither ran in CI.** This fixes both, clears every error, and adds a CI job so it can't rot again.

## 1. ESLint had no config at all

`bun run eslint` has **never** worked. The theme declares `eslint ^9` (plus `typescript-eslint`, the Prettier plugin, `globals`) but ships **no config file** — not a flat config, not even a legacy `.eslintrc`. ESLint 9 requires `eslint.config.*`, so every run died with *"ESLint couldn't find an eslint.config.(js|mjs|cjs) file."*

Adds `eslint.config.mjs` matching the theme's mixed module layout:

| scope | treated as |
|---|---|
| `js/**/*.js` | ESM bundled by Vite; browser globals + `Alpine`, `Drupal`, `drupalSettings`, `once` |
| `vite.config.js` | ESM, executed by Node — Vite injects `__dirname` |
| `prettier.config.js`, `stylelint.config.js` | CommonJS (`package.json` declares no `"type"`) |
| `**/*.ts` | typescript-eslint — inert today (no `.ts` sources) |

`eslint-plugin-prettier/recommended` goes **last**, since flat config is order-sensitive. The file is `.mjs` on purpose: with no `"type": "module"`, a root `eslint.config.js` would be parsed as CommonJS and choke on its own `import`s.

## 2. Stylelint's 56 errors

Two thirds were **Tailwind v4 false positives**, the rest genuine.

**Config — false positives:**
- `at-rule-no-unknown` (5): the ignore list predated Tailwind v4 and lacked `@source`. Added it, plus `@utility`/`@variant`/`@plugin`/`@reference`.
- `no-invalid-position-at-import-rule` (34): disabled. Tailwind/Vite inline the component `@import`s at build time, so the browser never sees an `@import` and the position isn't a spec violation. Hoisting them above `@theme`/`@layer` to satisfy the rule would **reorder the cascade**.

**CSS — genuine:**
- `node.css`, `tablesort.css` opened with `/ **` instead of `/**`. That's not a valid comment, so the parser read the docblock as a selector — the `Cannot parse selector` errors. **Compiled output is unaffected** (Lightning CSS recovers), but it's invalid CSS and it broke stylelint.
- Quoted `Georgia`/`Palatino`/`Garamond` in the font stacks so they're strings, not keywords. Preferred over the autofix, which lowercases them to `georgia`.
- Expanded the single-line `h1`/`h2`/`h3` rules; blank line before a comment.
- `@keyframes fadeInUp` → `fade-in-up`, with both `animation:` references updated. No references exist outside that file.

## 3. CI enforcement

New **`theme-lint`** job running both linters. Neither ran in CI before — which is precisely how ESLint stayed unconfigured and 56 stylelint errors accumulated unnoticed.

Invoked as `bunx eslint .` / `bunx stylelint "**/*.css"` rather than the `package.json` scripts, because the `eslint` script passes `--fix`: CI must **report** problems, not quietly rewrite the checkout and pass.

## Verification

- Both linters exit **0** under the exact commands CI runs (**without** `--fix`) — so the committed source is genuinely clean, not merely auto-fixable.
- ESLint's `--fix` pass rewrote no existing source, and a deliberately malformed probe file **was** caught — it genuinely lints rather than vacuously passing.
- Theme still builds: 239 modules, `styles.css` 50.16 kB.

### Correction

An earlier draft of this work claimed the `/ **` comment bug was silently dropping `.node--unpublished` and the tablesort rules from the compiled CSS. **That was wrong.** It was an artifact of DDEV's host↔container filesystem sync racing with `git stash`, so the build I measured didn't match the source I thought I'd reverted. Re-run entirely inside the container, output is byte-identical before and after. The comment fix is lint correctness, **not** a rendering fix.

## Note

Only `ci.yml` gets the lint job. `deploy.yml` duplicates the same job list and gates production on them — I left it alone so a lint failure can't block a hotfix deploy. Say the word if you'd rather it gate deploys too.